### PR TITLE
Adjusted example readme to mention 'make load' need root access.

### DIFF
--- a/example/README
+++ b/example/README
@@ -16,4 +16,4 @@ Assuming you are running on a Raspberry Pi 2-4 or Zero (tested with bullseye):
 
 4. Load the rot.bin file to the shield:
 
- make load
+ sudo make load


### PR DESCRIPTION
Without root access, the script report these errors:

  ./ice4pi_prog: line 3: /sys/class/gpio/gpio24/direction: Permission denied
  ./ice4pi_prog: line 4: /sys/class/gpio/gpio24/value: Permission denied
  ./ice4pi_prog: line 6: echo: write error: Operation not permitted

Besides these messages, the flashing seem to be successful.